### PR TITLE
chore: adopt `direnv`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# `.envrc` is run by `direnv(1)` when you `cd` into the directory
+# for more information, see: https://direnv.net/
+
+# load private environment variables from ./.env if it's present
+if [ -f .env ]; then
+  set -a # ensure assigning a variable exports it
+  source .env
+  set +a
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+.env
+.direnv


### PR DESCRIPTION
We could add `use flake` to this document, but I held off  since I'm not sure whether we're anticipating contributors who don't use `nix` in the future.  For now, we can always add `use flake` to `.env` -- if I get around to writing a flake.